### PR TITLE
Hotfix/hooked service override

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ extensions:
 crashLog:
 	filesystemService: <service-name>
 	delegateLoggerService: <service-name>
-
 ```
 
 Contributing

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - "7.0"
+  - "7.1"
 
 before_script:
   - composer self-update || echo "[ERROR] update-composer failed!"

--- a/src/main/php/DI/CrashLogExtension.php
+++ b/src/main/php/DI/CrashLogExtension.php
@@ -15,7 +15,7 @@ class CrashLogExtension extends CompilerExtension
 {
 
 	/**
-	 * @var array
+	 * @var mixed[]
 	 */
 	private $defaults = [
 		'logger' => FlysystemAdapter::class,
@@ -37,7 +37,7 @@ class CrashLogExtension extends CompilerExtension
 	/**
 	 * @inheritDoc
 	 */
-	public function loadConfiguration()
+	public function loadConfiguration() : void
 	{
 		$config = $this->validateConfig($this->defaults);
 		$builder = $this->getContainerBuilder();
@@ -66,7 +66,7 @@ class CrashLogExtension extends CompilerExtension
 	/**
 	 * @inheritdoc
 	 */
-	public function afterCompile(ClassType $class)
+	public function afterCompile(ClassType $class) : void
 	{
 		$config = $this->getConfig();
 		if ($config['hookToTracy'] === TRUE) {
@@ -86,7 +86,7 @@ class CrashLogExtension extends CompilerExtension
 
 
 	/**
-	 * @param array $config
+	 * @param mixed[] $config
 	 * @param ContainerBuilder $builder
 	 * @return string
 	 */

--- a/src/main/php/DI/CrashLogExtension.php
+++ b/src/main/php/DI/CrashLogExtension.php
@@ -29,6 +29,7 @@ class CrashLogExtension extends CompilerExtension
 		'filesystemService' => NULL,
 		'loggerServiceDelegate' => NULL,
 		'hookToTracy' => TRUE,
+		'hookedServiceOverride' => NULL,
 	];
 
 
@@ -71,8 +72,14 @@ class CrashLogExtension extends CompilerExtension
 		if ($config['hookToTracy'] === TRUE) {
 			$initialize = $class->getMethod('initialize');
 
+			if ($config['hookedServiceOverride'] === NULL) {
+				$exposedService = $this->prefix('logger');
+			} else {
+				$exposedService = ltrim($config['hookedServiceOverride'], '@');
+			}
+
 			$code = '\Tracy\Debugger::setLogger($this->getService(?));';
-			$initialize->addBody($code, [$this->prefix('logger')]);
+			$initialize->addBody($code, [$exposedService]);
 		}
 	}
 

--- a/src/main/php/FlysystemAdapter.php
+++ b/src/main/php/FlysystemAdapter.php
@@ -53,7 +53,7 @@ class FlysystemAdapter implements ILogger
 	/**
 	 * @inheritdoc
 	 */
-	public function log($value, $priority = self::INFO)
+	public function log($value, $priority = self::INFO) : void
 	{
 		if ($value instanceof \Throwable) {
 			try {

--- a/src/main/php/StreamShortLogger.php
+++ b/src/main/php/StreamShortLogger.php
@@ -48,7 +48,7 @@ class StreamShortLogger implements ILogger
 	 * @param  string|\Throwable
 	 * @return string
 	 */
-	protected function formatLogLine($message)
+	private function formatLogLine($message) : string
 	{
 		if ($message instanceof \Throwable) {
 			$dumpedMessage = $message->getMessage();

--- a/src/main/php/StreamShortLogger.php
+++ b/src/main/php/StreamShortLogger.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types = 1);
+
+namespace Damejidlo\CrashLog;
+
+use Tracy\Dumper;
+use Tracy\Helpers;
+use Tracy\ILogger;
+
+
+
+class StreamShortLogger implements ILogger
+{
+
+	/**
+	 * @var ILogger
+	 */
+	private $delegate;
+
+	/**
+	 * @var string
+	 */
+	private $destination;
+
+
+
+	public function __construct(ILogger $delegate, string $destination)
+	{
+		$this->delegate = $delegate;
+		$this->destination = $destination;
+	}
+
+
+
+	public function log($value, $priority = self::INFO) : void
+	{
+		$logLine = $this->formatLogLine($value) . PHP_EOL;
+		file_put_contents($this->destination, $logLine, FILE_APPEND);
+		$this->delegate->log($value, $priority);
+	}
+
+
+
+	/**
+	 * Adapted from: Copyright (c) 2004, 2014 David Grudl (https://davidgrudl.com)
+	 * All rights reserved. New BSD License - See tracy-license.md
+	 *
+	 * @param  string|\Throwable
+	 * @return string
+	 */
+	protected function formatLogLine($message)
+	{
+		if ($message instanceof \Throwable) {
+			$dumpedMessage = $message->getMessage();
+		} else {
+			$dumpedMessage = Dumper::toText($message);
+		}
+
+		$pieces = [
+			@date('[Y-m-d H-i-s]'), // @ timezone may not be set
+			preg_replace('#\s*\r?\n\s*#', ' ', $dumpedMessage),
+			' @  ' . Helpers::getSource(),
+		];
+		$logLine = implode(' ', $pieces);
+
+		return $logLine;
+	}
+
+}

--- a/src/test/php/FlysystemAdapterTest.phpt
+++ b/src/test/php/FlysystemAdapterTest.phpt
@@ -19,7 +19,7 @@ use Tracy\ILogger;
 class FlysystemAdapterTest extends TestCase
 {
 
-	public function testNonException()
+	public function testNonException() : void
 	{
 		$delegate = Mockery::mock(ILogger::class);
 		$delegate->shouldReceive('log')->with('foo', Mockery::any())->once();
@@ -37,7 +37,7 @@ class FlysystemAdapterTest extends TestCase
 
 
 
-	public function testFallbackLogging()
+	public function testFallbackLogging() : void
 	{
 		$loggingException = new \LogicException();
 		$logMessage = new \RuntimeException();
@@ -66,7 +66,7 @@ class FlysystemAdapterTest extends TestCase
 	 * @dataProvider happyPathExceptionProvider
 	 * @param \Throwable|NULL $exception
 	 */
-	public function testHappyPath(\Throwable $exception = NULL)
+	public function testHappyPath(\Throwable $exception = NULL) : void
 	{
 		$exceptionFilePath = '/bar/exception-123.html';
 
@@ -96,7 +96,7 @@ class FlysystemAdapterTest extends TestCase
 
 
 	/**
-	 * @return array
+	 * @return mixed[][]
 	 */
 	protected function happyPathExceptionProvider() : array
 	{
@@ -108,7 +108,7 @@ class FlysystemAdapterTest extends TestCase
 
 
 
-	protected function tearDown()
+	protected function tearDown() : void
 	{
 		Mockery::close();
 	}

--- a/src/test/php/LogPathProviderTest.phpt
+++ b/src/test/php/LogPathProviderTest.phpt
@@ -15,7 +15,7 @@ use Tester\TestCase;
 class LogPathProviderTest extends TestCase
 {
 
-	public function testGetExceptionFile()
+	public function testGetExceptionFile() : void
 	{
 		$exception = new \RuntimeException();
 


### PR DESCRIPTION
- Adds a new option `hookedServiceOverride` to the extension. It defines the DI service that shall be hooked to Tracy. It is designed to enable custom loggers handle the message before delegating it to `FlysystemAdapter`.
- Adds a new logger `StreamShortLogger` which uses the aforementioned `hookedServiceOverride` feature. It writes a short digest of the logged message into a stream - a file, `php://stderr` etc.